### PR TITLE
v.1.2.2 (April 8, 2020)

### DIFF
--- a/cheat_codes.lua
+++ b/cheat_codes.lua
@@ -2378,6 +2378,21 @@ function grid_redraw()
       end
     end
     
+    if a.device ~= nil then
+      for i = 1,3 do
+        for j = 5,15,5 do
+          g:led(j,8,arc_param[j/5] == 1 and 5 or 0)
+          g:led(j,7,arc_param[j/5] == 2 and 5 or 0)
+          g:led(j,6,arc_param[j/5] == 3 and 5 or 0)
+          if arc_param[j/5] == 4 then
+            for k = 8,6,-1 do
+              g:led(j,k,5)
+            end
+          end
+        end
+      end
+    end
+    
     for i = 1,3 do
       if bank[i].focus_hold == 0 then
         g:led(selected[i].x, selected[i].y, 15)

--- a/cheat_codes.lua
+++ b/cheat_codes.lua
@@ -2919,6 +2919,12 @@ function savestate()
   end
   io.write("1.2.1: arc patterning".."\n")
   io.write(params:get("arc_patterning").."\n")
+  io.write("1.2.2: crow_pad_execute".."\n")
+  for i = 1,3 do
+    for k = 1,16 do
+      io.write(bank[i][k].crow_pad_execute.."\n")
+    end
+  end
   io.close(file)
   if selected_coll ~= params:get("collection") then
     meta_copy_coll(selected_coll,params:get("collection"))
@@ -3105,8 +3111,15 @@ function loadstate()
         grid_pat[i].playmode = tonumber(io.read())
       end
     end
-    if io.read() == "1.2.1: arc patterning + osc settings" then
+    if io.read() == "1.2.1: arc patterning" then
       params:set("arc_patterning", tonumber(io.read()))
+    end
+    if io.read() == "1.2.2: crow_pad_execute" then
+      for i = 1,3 do
+        for k = 1,16 do
+          bank[i][k].crow_pad_execute = tonumber(io.read())
+        end
+      end
     end
     io.close(file)
     for i = 1,3 do

--- a/lib/grid_actions.lua
+++ b/lib/grid_actions.lua
@@ -395,17 +395,39 @@ function grid_actions.init(x,y,z)
       end
     end
     
-    for i = 8,5,-1 do
-      if z == 1 then
+    for i = 8,6,-1 do
+      --if z == 1 then
         if x == 5 or x == 10 or x == 15 then
           if y == i then
-            if grid.alt == 0 then
-              arc_param[x/5] = 9-y
-              if menu == 8 then
-                which_bank = x/5
-                help_menu = "arc params"
+            if z == 1 then
+              arc_switcher[x/5] = arc_switcher[x/5] + 1
+              if grid.alt == 0 and arc_switcher[x/5] == 1 then
+                arc_param[x/5] = 9-y
+                if menu == 8 then
+                  which_bank = x/5
+                  help_menu = "arc params"
+                end
+                redraw()
+              elseif grid.alt == 0 and arc_switcher[x/5] == 3 then
+                 arc_param[x/5] = 4
               end
-              redraw()
+            elseif z == 0 then
+              arc_switcher[x/5] = arc_switcher[x/5] - 1
+            end
+          end
+        end
+      --end
+    end
+    
+    if y == 5 and z == 1 then
+      for i = 1,3 do
+        if bank[i].focus_hold == 1 then
+          if x == i*5 then
+            bank[i][bank[i].focus_pad].crow_pad_execute = (bank[i][bank[i].focus_pad].crow_pad_execute + 1)%2
+            if grid.alt == 1 then
+              for j = 1,16 do
+                bank[i][j].crow_pad_execute = bank[i][bank[i].focus_pad].crow_pad_execute
+              end
             end
           end
         end


### PR DESCRIPTION
adds:

- crow per-pad output, as discussed with @shellfritsch. on grid, put a bank into pad focus mode and you’ll see a bright LED under the bottom right corner of the bank. toggle it on/off to send a crow pulse when that pad is pressed. grid-ALT + that toggle to switch all pads at once.
- arc pattern save, as discussed with @laborcamp. no menu item, super straightforward. if you save a collection with an arc pattern on any encoder, it will save with your collection. if you load a collection that had arc patterns on any encoder, they will restore.

changes:

- to make room for crow-pad output, the arc selector for filter has turned into a three-finger press on the first three arc pads. this feels like an improvement overall!