### PR TITLE
pad.id -> pad.pad_id

### DIFF
--- a/lib/zilchmos.lua
+++ b/lib/zilchmos.lua
@@ -204,7 +204,7 @@ function zilchmos.sc.play_toggle( pad, i )
     softcut.rate(i+1, 0.0)
   else
     if pad.enveloped then
-      cheat( i, pad.id )
+      cheat( i, pad.pad_id )
     else
       softcut.level(i+1, pad.level)
     end
@@ -242,7 +242,7 @@ end
 
 function zilchmos.sc.cheat( pad, i, p )
   if pad.loop and not pad.enveloped then
-    cheat( i, pad.id )
+    cheat( i, pad.pad_id )
   end
 end
 


### PR DESCRIPTION
> there’s something weird going on with the 12 action on the 4th Zilchmo row on all banks (randomize start point). Even though it does appear to move the start point on the loops screen, the change doesn’t take effect immediately like it does with the 34 action (the play head continues looping from wherever the start point was before, until you trigger the current pad again), and the grid LEDs get stuck until you hit another Zilchmo key. Here’s the error I get in Maiden:
> 
```
lua: /home/we/dust/code/cheat_codes/cheat_codes.lua:1337: attempt to index a nil value (local 'pad')
stack traceback:
        /home/we/dust/code/cheat_codes/cheat_codes.lua:1337: in global 'cheat'
        /home/we/dust/code/cheat_codes/lib/zilchmos.lua:245: in local 'sc_action'
        /home/we/dust/code/cheat_codes/lib/zilchmos.lua:39: in field 'init'
        /home/we/dust/code/cheat_codes/cheat_codes.lua:2090: in global 'zilchmo'
        /home/we/dust/code/cheat_codes/cheat_codes.lua:824: in field 'event'
        /home/we/norns/lua/core/metro.lua:169: in function </home/we/norns/lua/core/metro.lua:166>
```