### PR TITLE
v1.3.1

### DIFF
--- a/cheat_codes.lua
+++ b/cheat_codes.lua
@@ -924,7 +924,7 @@ function pad_clock()
 end
 
 function one_shot_clock()
-  local divs = {0.25,1}
+  local divs = {1,0.25}
   local rate = 1/divs[params:get("one_shot_clock_div")]
   clock.sync(rate)
   softcut.position(1,rec.start_point)

--- a/cheat_codes.lua
+++ b/cheat_codes.lua
@@ -1488,7 +1488,11 @@ function cheat(b,i)
     s[v]=k
   end
   if pad.fifth == false then
-    params:set("rate "..tonumber(string.format("%.0f",b)),s[pad.rate])
+    if s[pad.rate] ~= nil then
+      params:set("rate "..tonumber(string.format("%.0f",b)),s[pad.rate])
+    else
+      pad.fifth = true
+    end
   end
   params:set("level "..tonumber(string.format("%.0f",b)),pad.level)
   params:set("current pad "..tonumber(string.format("%.0f",b)),i,"true")

--- a/cheat_codes.lua
+++ b/cheat_codes.lua
@@ -951,7 +951,8 @@ function compare_rec_resolution(x)
   rec_loop_enc_resolution = resolutions[x]
   if x > 2 then
     rec.start_point = 1+(8*(rec.clip-1))
-    rec.end_point = (1+(8*(rec.clip-1) + (1/rec_loop_enc_resolution))/params:get("live_buff_rate"))
+    local lbr = {1,2,4}
+    rec.end_point = (1+(8*(rec.clip-1) + (1/rec_loop_enc_resolution))/lbr[params:get("live_buff_rate")])
     softcut.loop_start(1,rec.start_point)
     softcut.loop_end(1,rec.end_point)
     redraw()

--- a/cheat_codes.lua
+++ b/cheat_codes.lua
@@ -1337,7 +1337,6 @@ function pad_to_rec(b)
   softcut.loop_end(1,rec.end_point-0.01)
   softcut.position(1,rec.start_point)
 end
-  
 
 function reset_all_banks( banks )
   cross_filter = {} -- TODO put into the banks

--- a/lib/encoder_actions.lua
+++ b/lib/encoder_actions.lua
@@ -45,14 +45,9 @@ function encoder_actions.init(n,d)
         else
           local current_difference = (rec.end_point - rec.start_point)
           if rec.start_point + current_difference < (9+(8*(rec.clip-1))) then
-            --rec.start_point = util.clamp(rec.start_point + d/loop_enc_resolution,(1+(8*(rec.clip-1))),(9+(8*(rec.clip-1))))
             rec.start_point = util.clamp(rec.start_point + current_difference * (d>0 and 1 or -1), (1+(8*(rec.clip-1))),(9+(8*(rec.clip-1))))
             rec.end_point = rec.start_point + current_difference
           else
-            --[[
-            rec.end_point = (9+(8*(rec.clip-1)))
-            rec.start_point = rec.end_point - current_difference
-            --]]
             rec.end_point = util.clamp(rec.end_point + current_difference * (d>0 and 1 or -1), (1+(8*(rec.clip-1))),(9+(8*(rec.clip-1))))
             rec.start_point = rec.end_point - current_difference
           end
@@ -139,10 +134,10 @@ function encoder_actions.init(n,d)
             end
           end
         else
-          if d >= 0 and rec.start_point < (rec.end_point - d/loop_enc_resolution) then
-            rec.start_point = util.clamp(rec.start_point+d/loop_enc_resolution,(1+(8*(rec.clip-1))),(8.9+(8*(rec.clip-1))))
+          if d >= 0 and rec.start_point < (rec.end_point - d/rec_loop_enc_resolution) then
+            rec.start_point = util.clamp(rec.start_point+d/rec_loop_enc_resolution,(1+(8*(rec.clip-1))),(8.9+(8*(rec.clip-1))))
           elseif d < 0 then
-            rec.start_point = util.clamp(rec.start_point+d/loop_enc_resolution,(1+(8*(rec.clip-1))),(8.9+(8*(rec.clip-1))))
+            rec.start_point = util.clamp(rec.start_point+d/rec_loop_enc_resolution,(1+(8*(rec.clip-1))),(8.9+(8*(rec.clip-1))))
           end
           softcut.loop_start(1, rec.start_point)
         end
@@ -240,10 +235,10 @@ function encoder_actions.init(n,d)
         if key1_hold or grid.alt == 1 then
           params:delta("live_buff_rate",d)
         else
-          if d <= 0 and rec.start_point < rec.end_point + d/loop_enc_resolution then
-            rec.end_point = util.clamp(rec.end_point+d/loop_enc_resolution,(1+(8*(rec.clip-1))),(9+(8*(rec.clip-1))))
+          if d <= 0 and rec.start_point < rec.end_point + d/rec_loop_enc_resolution then
+            rec.end_point = util.clamp(rec.end_point+d/rec_loop_enc_resolution,(1+(8*(rec.clip-1))),(9+(8*(rec.clip-1))))
           elseif d > 0 then
-            rec.end_point = util.clamp(rec.end_point+d/loop_enc_resolution,(1+(8*(rec.clip-1))),(9+(8*(rec.clip-1))))
+            rec.end_point = util.clamp(rec.end_point+d/rec_loop_enc_resolution,(1+(8*(rec.clip-1))),(9+(8*(rec.clip-1))))
           end
           softcut.loop_end(1, rec.end_point-0.01)
         end

--- a/lib/encoder_actions.lua
+++ b/lib/encoder_actions.lua
@@ -138,11 +138,12 @@ function encoder_actions.init(n,d)
             end
           end
         else
+          local lbr = {1,2,4}
           --if d >= 0 and rec.start_point + ((d/rec_loop_enc_resolution)/params:get("live_buff_rate")) < (rec.end_point - ((d/rec_loop_enc_resolution)/params:get("live_buff_rate"))) then
-          if d >= 0 and rec.start_point + ((d/rec_loop_enc_resolution)/params:get("live_buff_rate")) < rec.end_point then
-            rec.start_point = util.clamp(rec.start_point+((d/rec_loop_enc_resolution)/params:get("live_buff_rate")),(1+(8*(rec.clip-1))),(8.9+(8*(rec.clip-1))))
+          if d >= 0 and rec.start_point + ((d/rec_loop_enc_resolution)/lbr[params:get("live_buff_rate")]) < rec.end_point then
+            rec.start_point = util.clamp(rec.start_point+((d/rec_loop_enc_resolution)/lbr[params:get("live_buff_rate")]),(1+(8*(rec.clip-1))),(8.9+(8*(rec.clip-1))))
           elseif d < 0 then
-            rec.start_point = util.clamp(rec.start_point+((d/rec_loop_enc_resolution)/params:get("live_buff_rate")),(1+(8*(rec.clip-1))),(8.9+(8*(rec.clip-1))))
+            rec.start_point = util.clamp(rec.start_point+((d/rec_loop_enc_resolution)/lbr[params:get("live_buff_rate")]),(1+(8*(rec.clip-1))),(8.9+(8*(rec.clip-1))))
           end
           softcut.loop_start(1, rec.start_point)
         end
@@ -240,10 +241,11 @@ function encoder_actions.init(n,d)
         if key1_hold or grid.alt == 1 then
           params:delta("live_buff_rate",d)
         else
-          if d <= 0 and rec.start_point < rec.end_point + ((d/rec_loop_enc_resolution)/params:get("live_buff_rate")) then
-            rec.end_point = util.clamp(rec.end_point+((d/rec_loop_enc_resolution)/params:get("live_buff_rate")),(1+(8*(rec.clip-1))),(9+(8*(rec.clip-1))))
-          elseif d > 0 and rec.end_point+((d/rec_loop_enc_resolution)/params:get("live_buff_rate")) < 9+(8*(rec.clip-1)) then
-            rec.end_point = util.clamp(rec.end_point+((d/rec_loop_enc_resolution)/params:get("live_buff_rate")),(1+(8*(rec.clip-1))),(9+(8*(rec.clip-1))))
+          local lbr = {1,2,4}
+          if d <= 0 and rec.start_point < rec.end_point + ((d/rec_loop_enc_resolution)/lbr[params:get("live_buff_rate")]) then
+            rec.end_point = util.clamp(rec.end_point+((d/rec_loop_enc_resolution)/lbr[params:get("live_buff_rate")]),(1+(8*(rec.clip-1))),(9+(8*(rec.clip-1))))
+          elseif d > 0 and rec.end_point+((d/rec_loop_enc_resolution)/lbr[params:get("live_buff_rate")]) < 9+(8*(rec.clip-1)) then
+            rec.end_point = util.clamp(rec.end_point+((d/rec_loop_enc_resolution)/lbr[params:get("live_buff_rate")]),(1+(8*(rec.clip-1))),(9+(8*(rec.clip-1))))
           end
           softcut.loop_end(1, rec.end_point-0.01)
         end

--- a/lib/encoder_actions.lua
+++ b/lib/encoder_actions.lua
@@ -44,12 +44,16 @@ function encoder_actions.init(n,d)
           rec.end_point = rec.start_point + current_difference
         else
           local current_difference = (rec.end_point - rec.start_point)
-          if rec.start_point + current_difference < (9+(8*(rec.clip-1))) then
-            rec.start_point = util.clamp(rec.start_point + current_difference * (d>0 and 1 or -1), (1+(8*(rec.clip-1))),(9+(8*(rec.clip-1))))
-            rec.end_point = rec.start_point + current_difference
+          if d >=0 then
+            if rec.end_point + current_difference < (9+(8*(rec.clip-1))) then
+              rec.start_point = util.clamp(rec.start_point + current_difference * (d>0 and 1 or -1), (1+(8*(rec.clip-1))),(9+(8*(rec.clip-1))))
+              rec.end_point = rec.start_point + current_difference
+            end
           else
-            rec.end_point = util.clamp(rec.end_point + current_difference * (d>0 and 1 or -1), (1+(8*(rec.clip-1))),(9+(8*(rec.clip-1))))
-            rec.start_point = rec.end_point - current_difference
+            if rec.end_point - current_difference > (1+(8*(rec.clip-1))) then
+              rec.end_point = util.clamp(rec.end_point + current_difference * (d>0 and 1 or -1), (1+(8*(rec.clip-1))),(9+(8*(rec.clip-1))))
+              rec.start_point = rec.end_point - current_difference
+            end
           end
         end
         softcut.loop_start(1,rec.start_point)
@@ -134,10 +138,11 @@ function encoder_actions.init(n,d)
             end
           end
         else
-          if d >= 0 and rec.start_point < (rec.end_point - d/rec_loop_enc_resolution) then
-            rec.start_point = util.clamp(rec.start_point+d/rec_loop_enc_resolution,(1+(8*(rec.clip-1))),(8.9+(8*(rec.clip-1))))
+          --if d >= 0 and rec.start_point + ((d/rec_loop_enc_resolution)/params:get("live_buff_rate")) < (rec.end_point - ((d/rec_loop_enc_resolution)/params:get("live_buff_rate"))) then
+          if d >= 0 and rec.start_point + ((d/rec_loop_enc_resolution)/params:get("live_buff_rate")) < rec.end_point then
+            rec.start_point = util.clamp(rec.start_point+((d/rec_loop_enc_resolution)/params:get("live_buff_rate")),(1+(8*(rec.clip-1))),(8.9+(8*(rec.clip-1))))
           elseif d < 0 then
-            rec.start_point = util.clamp(rec.start_point+d/rec_loop_enc_resolution,(1+(8*(rec.clip-1))),(8.9+(8*(rec.clip-1))))
+            rec.start_point = util.clamp(rec.start_point+((d/rec_loop_enc_resolution)/params:get("live_buff_rate")),(1+(8*(rec.clip-1))),(8.9+(8*(rec.clip-1))))
           end
           softcut.loop_start(1, rec.start_point)
         end
@@ -235,10 +240,10 @@ function encoder_actions.init(n,d)
         if key1_hold or grid.alt == 1 then
           params:delta("live_buff_rate",d)
         else
-          if d <= 0 and rec.start_point < rec.end_point + d/rec_loop_enc_resolution then
-            rec.end_point = util.clamp(rec.end_point+d/rec_loop_enc_resolution,(1+(8*(rec.clip-1))),(9+(8*(rec.clip-1))))
-          elseif d > 0 then
-            rec.end_point = util.clamp(rec.end_point+d/rec_loop_enc_resolution,(1+(8*(rec.clip-1))),(9+(8*(rec.clip-1))))
+          if d <= 0 and rec.start_point < rec.end_point + ((d/rec_loop_enc_resolution)/params:get("live_buff_rate")) then
+            rec.end_point = util.clamp(rec.end_point+((d/rec_loop_enc_resolution)/params:get("live_buff_rate")),(1+(8*(rec.clip-1))),(9+(8*(rec.clip-1))))
+          elseif d > 0 and rec.end_point+((d/rec_loop_enc_resolution)/params:get("live_buff_rate")) < 9+(8*(rec.clip-1)) then
+            rec.end_point = util.clamp(rec.end_point+((d/rec_loop_enc_resolution)/params:get("live_buff_rate")),(1+(8*(rec.clip-1))),(9+(8*(rec.clip-1))))
           end
           softcut.loop_end(1, rec.end_point-0.01)
         end

--- a/lib/grid_actions.lua
+++ b/lib/grid_actions.lua
@@ -373,6 +373,8 @@ function grid_actions.init(x,y,z)
                 if y == 8 then
                   sixteen_slices(x/5)
                 elseif y == 7 then
+                  rec_to_pad(x/5)
+                elseif y == 6 then
                   pad_to_rec(x/5)
                 end
               end

--- a/lib/grid_actions.lua
+++ b/lib/grid_actions.lua
@@ -321,6 +321,7 @@ function grid_actions.init(x,y,z)
         end
         
         if rec.loop == 0 and grid.alt == 0 then
+          --[[
           softcut.position(1,rec.start_point)
           if rec.state == 0 then
             rec.state = 1
@@ -328,6 +329,8 @@ function grid_actions.init(x,y,z)
             rec_state_watcher:start()
             end
           if rec.clear == 1 then rec.clear = 0 end
+          --]]
+          clock.run(one_shot_clock)
         elseif rec.loop == 0 and grid.alt == 1 then
           buff_flush()
         end
@@ -366,6 +369,12 @@ function grid_actions.init(x,y,z)
                 redraw()
               elseif grid.alt == 0 and arc_switcher[x/5] == 3 then
                  arc_param[x/5] = 4
+              elseif grid.alt == 1 then
+                if y == 8 then
+                  sixteen_slices(x/5)
+                elseif y == 7 then
+                  pad_to_rec(x/5)
+                end
               end
             elseif z == 0 then
               arc_switcher[x/5] = arc_switcher[x/5] - 1

--- a/lib/main_menu.lua
+++ b/lib/main_menu.lua
@@ -328,8 +328,6 @@ function main_menu.init()
     screen.level(3)
     screen.text("timing")
     screen.level(3)
-    --screen.move(100,10)
-    --screen.text(params:get("bpm") >= 1 and ("bpm: "..params:get("bpm")) or "too slow")
     screen.move(110,10)
     local show_me_beats = clock.get_beats() % 4
     local show_me_frac = math.fmod(clock.get_beats(),1)

--- a/lib/start_up.lua
+++ b/lib/start_up.lua
@@ -153,7 +153,8 @@ function start_up.init()
     end
   )
   
-  params:add_option("loop_enc_resolution", "play loop enc resolution", {"0.1","0.01","1/16","1/8","1/4","1/2","1 bar"}, 1)
+  --params:add_option("loop_enc_resolution", "play loop enc resolution", {"0.1","0.01","1/16","1/8","1/4","1/2","1 bar"}, 1)
+  params:add_option("loop_enc_resolution", "play loop enc resolution", {"0.1","0.01"}, 1)
   params:set_action("loop_enc_resolution", function(x)
     local resolutions =
     { [1] = 10
@@ -167,7 +168,7 @@ function start_up.init()
     loop_enc_resolution = resolutions[x]
   end)
   
-  --params:add_separator()
+  --params:add_option("zilchmo_bind_rand","bind random zilchmo?", {"no","yes"}, 1)
   
   params:add_group("grid/arc pattern params",2)
   params:add_option("zilchmo_patterning", "grid pattern style", { "classic", "rad sauce" })

--- a/lib/start_up.lua
+++ b/lib/start_up.lua
@@ -97,7 +97,7 @@ function start_up.init()
     end
   )
 
-  params:add_option("one_shot_clock_div","1-shot sync div",{"next beat","next bar"},1)
+  params:add_option("one_shot_clock_div","--> 1-shot sync",{"next beat","next bar"},1)
 
   params:add_option("rec_loop_enc_resolution", "rec loop enc resolution", {"0.1","0.01","1/16","1/8","1/4","1/2","1 bar"}, 1)
   params:set_action("rec_loop_enc_resolution", function(x)
@@ -113,18 +113,12 @@ function start_up.init()
     rec_loop_enc_resolution = resolutions[x]
     if x > 2 then
       rec.start_point = 1+(8*(rec.clip-1))
-      rec.end_point = (1+(8*(rec.clip-1) + (1/rec_loop_enc_resolution))*params:get("live_buff_rate"))
+      rec.end_point = (1+(8*(rec.clip-1) + (1/rec_loop_enc_resolution))/params:get("live_buff_rate"))
       softcut.loop_start(1,rec.start_point)
       softcut.loop_end(1,rec.end_point)
     end
   end)
-  
-  params:add_option("live_buff_rate", "Live buffer max", {"8 sec", "16 sec", "32 sec"}, 1)
-  params:set_action("live_buff_rate", function(x)
-    local buff_rates = {1,0.5,0.25}
-    softcut.rate(1,buff_rates[x])
-  end)
-  
+
   params:add{id="live_rec_feedback", name="live rec feedback", type="control", 
   controlspec=controlspec.new(0,1.0,'lin',0,0.25,""),
   action=function(x)
@@ -132,6 +126,13 @@ function start_up.init()
       softcut.pre_level(1,x)
     end
   end}
+  
+  params:add_option("live_buff_rate", "live buffer max", {"8 sec", "16 sec", "32 sec"}, 1)
+  params:set_action("live_buff_rate", function(x)
+    local buff_rates = {1,0.5,0.25}
+    softcut.rate(1,buff_rates[x])
+    compare_rec_resolution(params:get("rec_loop_enc_resolution"))
+  end)
 
   params:add_separator("global")
 

--- a/lib/start_up.lua
+++ b/lib/start_up.lua
@@ -66,7 +66,7 @@ function start_up.init()
   
   --params:add_separator()
   
-  params:add_group("loops + buffers", 8)
+  params:add_group("loops + buffers", 10)
   
   for i = 1,3 do
     params:add_file("clip "..i.." sample", "clip "..i.." sample")
@@ -99,6 +99,8 @@ function start_up.init()
     end
   )
 
+  params:add_option("one_shot_clock_div","1-shot sync division",{"next bar","next beat"},1)
+
   params:add_control("offset", "global pitch offset", controlspec.new(-24, 24, 'lin', 1, 0, "st"))
   params:set_action("offset",
     function(value)
@@ -113,7 +115,7 @@ function start_up.init()
     end
   )
   
-  params:add_option("loop_enc_resolution", "loop encoder resolution", {"0.1","0.01","1/16","1/8","1/4","1/2","1 bar"}, 1)
+  params:add_option("loop_enc_resolution", "play loop enc resolution", {"0.1","0.01","1/16","1/8","1/4","1/2","1 bar"}, 1)
   params:set_action("loop_enc_resolution", function(x)
     local resolutions =
     { [1] = 10
@@ -125,6 +127,26 @@ function start_up.init()
     , [7] = (1/((60/bpm)))/4
     }
     loop_enc_resolution = resolutions[x]
+  end)
+
+  params:add_option("rec_loop_enc_resolution", "rec loop enc resolution", {"0.1","0.01","1/16","1/8","1/4","1/2","1 bar"}, 1)
+  params:set_action("rec_loop_enc_resolution", function(x)
+    local resolutions =
+    { [1] = 10
+    , [2] = 100
+    , [3] = 1/((60/bpm)/4)
+    , [4] = 1/((60/bpm)/2)
+    , [5] = 1/((60/bpm))
+    , [6] = (1/((60/bpm)))/2
+    , [7] = (1/((60/bpm)))/4
+    }
+    rec_loop_enc_resolution = resolutions[x]
+    if x > 2 then
+      rec.start_point = 1+(8*(rec.clip-1))
+      rec.end_point = (1+(8*(rec.clip-1) + (1/rec_loop_enc_resolution))*params:get("live_buff_rate"))
+      softcut.loop_start(1,rec.start_point)
+      softcut.loop_end(1,rec.end_point)
+    end
   end)
   
   params:add_option("live_buff_rate", "Live buffer max", {"8 sec", "16 sec", "32 sec"}, 1)

--- a/lib/start_up.lua
+++ b/lib/start_up.lua
@@ -87,11 +87,12 @@ function start_up.init()
       rec.loop = 2-x
       softcut.loop(1,rec.loop)
       softcut.position(1,rec.start_point)
-      rec.state = 1
-      rec.clear = 0
+      --rec.state = 1
+      rec.state = 0
+      --rec.clear = 0
       softcut.rec_level(1,rec.state)
       if x == 2 then
-        rec_state_watcher:start()
+        --rec_state_watcher:start()
         softcut.pre_level(1,params:get("live_rec_feedback"))
       elseif x == 1 then
         softcut.pre_level(1,params:get("live_rec_feedback"))
@@ -99,7 +100,7 @@ function start_up.init()
     end
   )
 
-  params:add_option("one_shot_clock_div","1-shot sync division",{"next bar","next beat"},1)
+  params:add_option("one_shot_clock_div","1-shot sync div",{"next beat","next bar"},1)
 
   params:add_control("offset", "global pitch offset", controlspec.new(-24, 24, 'lin', 1, 0, "st"))
   params:set_action("offset",

--- a/lib/start_up.lua
+++ b/lib/start_up.lua
@@ -66,20 +66,17 @@ function start_up.init()
   
   --params:add_separator()
   
-  params:add_group("loops + buffers", 10)
+  params:add_group("loops + buffers", 13)
+
+  params:add_separator("clips")
   
   for i = 1,3 do
     params:add_file("clip "..i.." sample", "clip "..i.." sample")
     params:set_action("clip "..i.." sample", function(file) load_sample(file,i) end)
   end
-  
-  params:add{id="live_rec_feedback", name="live rec feedback", type="control", 
-  controlspec=controlspec.new(0,1.0,'lin',0,0.25,""),
-  action=function(x)
-    if rec.state == 1 then
-      softcut.pre_level(1,x)
-    end
-  end}
+
+  params:add_separator("live")
+
 
   params:add_option("rec_loop", "live rec behavior", {"loop","1-shot"}, 1)
   params:set_action("rec_loop",
@@ -101,6 +98,42 @@ function start_up.init()
   )
 
   params:add_option("one_shot_clock_div","1-shot sync div",{"next beat","next bar"},1)
+
+  params:add_option("rec_loop_enc_resolution", "rec loop enc resolution", {"0.1","0.01","1/16","1/8","1/4","1/2","1 bar"}, 1)
+  params:set_action("rec_loop_enc_resolution", function(x)
+    local resolutions =
+    { [1] = 10
+    , [2] = 100
+    , [3] = 1/((60/bpm)/4)
+    , [4] = 1/((60/bpm)/2)
+    , [5] = 1/((60/bpm))
+    , [6] = (1/((60/bpm)))/2
+    , [7] = (1/((60/bpm)))/4
+    }
+    rec_loop_enc_resolution = resolutions[x]
+    if x > 2 then
+      rec.start_point = 1+(8*(rec.clip-1))
+      rec.end_point = (1+(8*(rec.clip-1) + (1/rec_loop_enc_resolution))*params:get("live_buff_rate"))
+      softcut.loop_start(1,rec.start_point)
+      softcut.loop_end(1,rec.end_point)
+    end
+  end)
+  
+  params:add_option("live_buff_rate", "Live buffer max", {"8 sec", "16 sec", "32 sec"}, 1)
+  params:set_action("live_buff_rate", function(x)
+    local buff_rates = {1,0.5,0.25}
+    softcut.rate(1,buff_rates[x])
+  end)
+  
+  params:add{id="live_rec_feedback", name="live rec feedback", type="control", 
+  controlspec=controlspec.new(0,1.0,'lin',0,0.25,""),
+  action=function(x)
+    if rec.state == 1 then
+      softcut.pre_level(1,x)
+    end
+  end}
+
+  params:add_separator("global")
 
   params:add_control("offset", "global pitch offset", controlspec.new(-24, 24, 'lin', 1, 0, "st"))
   params:set_action("offset",
@@ -128,32 +161,6 @@ function start_up.init()
     , [7] = (1/((60/bpm)))/4
     }
     loop_enc_resolution = resolutions[x]
-  end)
-
-  params:add_option("rec_loop_enc_resolution", "rec loop enc resolution", {"0.1","0.01","1/16","1/8","1/4","1/2","1 bar"}, 1)
-  params:set_action("rec_loop_enc_resolution", function(x)
-    local resolutions =
-    { [1] = 10
-    , [2] = 100
-    , [3] = 1/((60/bpm)/4)
-    , [4] = 1/((60/bpm)/2)
-    , [5] = 1/((60/bpm))
-    , [6] = (1/((60/bpm)))/2
-    , [7] = (1/((60/bpm)))/4
-    }
-    rec_loop_enc_resolution = resolutions[x]
-    if x > 2 then
-      rec.start_point = 1+(8*(rec.clip-1))
-      rec.end_point = (1+(8*(rec.clip-1) + (1/rec_loop_enc_resolution))*params:get("live_buff_rate"))
-      softcut.loop_start(1,rec.start_point)
-      softcut.loop_end(1,rec.end_point)
-    end
-  end)
-  
-  params:add_option("live_buff_rate", "Live buffer max", {"8 sec", "16 sec", "32 sec"}, 1)
-  params:set_action("live_buff_rate", function(x)
-    local buff_rates = {1,0.5,0.25}
-    softcut.rate(1,buff_rates[x])
   end)
   
   --params:add_separator()

--- a/lib/start_up.lua
+++ b/lib/start_up.lua
@@ -113,7 +113,8 @@ function start_up.init()
     rec_loop_enc_resolution = resolutions[x]
     if x > 2 then
       rec.start_point = 1+(8*(rec.clip-1))
-      rec.end_point = (1+(8*(rec.clip-1) + (1/rec_loop_enc_resolution))/params:get("live_buff_rate"))
+      local lbr = {1,2,4}
+      rec.end_point = (1+(8*(rec.clip-1) + (1/rec_loop_enc_resolution))/lbr[params:get("live_buff_rate")])
       softcut.loop_start(1,rec.start_point)
       softcut.loop_end(1,rec.end_point)
     end
@@ -132,6 +133,8 @@ function start_up.init()
     local buff_rates = {1,0.5,0.25}
     softcut.rate(1,buff_rates[x])
     compare_rec_resolution(params:get("rec_loop_enc_resolution"))
+    local rate_offset = {0,-12,-24}
+    params:set("offset",rate_offset[x])
   end)
 
   params:add_separator("global")

--- a/lib/zilchmos.lua
+++ b/lib/zilchmos.lua
@@ -118,9 +118,15 @@ end
 
 function zilchmos.end_random( pad )
   local current_start = math.floor(pad.start_point * 100)
-  local max_end = math.floor(((8*pad.clip)+1) * 100)
+  local max_end = nil
+  --if params:get("zilchmo_bind_rand") == 1 then
+    max_end = math.floor(((8*pad.clip)+1) * 100)
+  --else
+    --max_end = math.floor(rec.end_point * 100)
+  --end
   pad.end_point = math.random(current_start,max_end)/100
 end
+
 
 function zilchmos.start_end_random( pad )
   local jump = math.random(100,900)/100+(8*(pad.clip-1))


### PR DESCRIPTION
added:
- param: rec_loop_enc_resolution, which sets the Live buffer loop to a bpm-aware length
- param: one_shot_clock_div, which quantizes the Live buffer 1-shot engage to next bar or next beat
- clock co-routine: one_shot_clock, which quantizes the 1-shot engage
- `cheat` call inside of sixteen slices
- WEIRD: needed to place a 0.1s offset to record buffer for 1-shot live sampling...idk why, but it works now.

changed:
- swapped rec_loop_enc_resolution in for Live buffer loop point manipulation
- on boot, rec.state = 0
- when you swap between 1-shot and loop, recording does not automatically restart
- swapped "next beat" and "next bar" in params("one_shot_clock_div")
- default state no longer loops, which means folks don't have to turn it off when they're sampling
- no init error when another param is called inside of `update_tempo()`
- rec_state_watcher.time = 0.05 (was 0.25), which improves responsiveness of 1-shot LED
- changing live_buff_rate affects global rate!

fixed:
- when loading a pre-1.3 collection that had broken fifths saved to it, rate and fifth-awareness were unsynced. so, when you played a pad that had an old "0.75 rate but .fifth is false" in it, recalling would break because it was trying to set the rate param with a value that didn't exist.
- rec.end_point is now divided by live_buff_rate, so 1 bar at 0.5 = 2 bars instead of 4 bars
- auto-slice doesn't trigger cheat unless pad is looping
- if distance between pad end_point and start_point is less than 0.11, then distance auto-adjusts to 0.1
- manage double-tapping 1-shot record