### PR TITLE
v1.3.1 (200504)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,16 @@ a sample playground for norns
 
 ### Requirements
 
-- norns (200328 or later)
+- norns (200424 or later)
 - grid strongly encouraged, not required
 - arc strongly encouraged, not required
 - TouchOSC strongly encouraged, not required
 
 ### Documentation
 
-In-depth manual + discussion located [on lines](https://llllllll.co/t/30329).
+PDF manual + discussion located [on lines](https://llllllll.co/t/31655).
+
+Tutorial videos:
+
+- *livestream:* [live buffers + v1.3 features](https://youtu.be/dNlWIG53YBQ)
+- *tutorial:* [timing](https://youtu.be/s0PmjYkaaK4)

--- a/cheat_codes.lua
+++ b/cheat_codes.lua
@@ -937,7 +937,6 @@ function random_rec_clock()
           buff_freeze()
         elseif params:get("rec_loop") == 2 then
           if not rec_state_watcher.is_running then
-            local butts = tostring(rec_state_watcher.is_running)
             softcut.position(1,rec.start_point+0.1)
             softcut.rec_level(1,1)
             rec.state = 1
@@ -951,12 +950,14 @@ function random_rec_clock()
 end
 
 function one_shot_clock()
-  local divs = {1,4}
-  local rate = divs[params:get("one_shot_clock_div")]
   if rec.state == 1 and rec_state_watcher.is_running then
     rec_state_watcher:stop()
   end
-  clock.sync(rate)
+  if params:get("one_shot_clock_div") < 3 then
+    local divs = {1,4}
+    local rate = divs[params:get("one_shot_clock_div")]
+    clock.sync(rate)
+  end
   softcut.position(1,rec.start_point+0.1)
   softcut.rec_level(1,1)
   rec.state = 1

--- a/cheat_codes.lua
+++ b/cheat_codes.lua
@@ -905,7 +905,7 @@ function init()
   
   task_id = clock.run(globally_clocked)
   pad_press_quant = clock.run(pad_clock)
-  --one_shot_quant = clock.run(one_shot_clock)
+  random_rec = clock.run(random_rec_clock)
   
   if params:string("clock_source") == "internal" then
     clock.internal.start(bpm)
@@ -922,25 +922,37 @@ function pad_clock()
   end
 end
 
+function random_rec_clock()
+  while true do
+    local lbr = {1,2,4}
+    local rler = rec_loop_enc_resolution
+    local rec_distance = rec.end_point - rec.start_point
+    local bar_count = params:get("rec_loop_enc_resolution") > 2 and (((rec_distance)/(1/rler)) / (rler))*(2*lbr[params:get("live_buff_rate")]) or 1/4
+    clock.sync(params:get("rec_loop") == 1 and 4 or bar_count)
+    local random_rec_prob = params:get("random_rec_clock_prob")
+    if random_rec_prob > 0 then
+      local random_rec_comp = math.random(0,100)
+      if random_rec_comp < random_rec_prob then
+        if params:get("rec_loop") == 1 then
+          buff_freeze()
+        elseif params:get("rec_loop") == 2 then
+          if not rec_state_watcher.is_running then
+            local butts = tostring(rec_state_watcher.is_running)
+            softcut.position(1,rec.start_point+0.1)
+            softcut.rec_level(1,1)
+            rec.state = 1
+            rec_state_watcher:start()
+            if rec.clear == 1 then rec.clear = 0 end
+          end
+        end
+      end
+    end
+  end
+end
+
 function one_shot_clock()
   local divs = {1,4}
   local rate = divs[params:get("one_shot_clock_div")]
-  --[[
-  if rec.state == 0 and not rec_state_watcher.is_running then
-    clock.sync(rate)
-    softcut.position(1,rec.start_point+0.1)
-    softcut.rec_level(1,1)
-    rec.state = 1
-    rec_state_watcher:start()
-  elseif rec.state == 1 and rec_state_watcher.is_running then
-    rec_state_watcher:stop()
-    clock.sync(rate)
-    softcut.position(1,rec.start_point+0.1)
-    softcut.rec_level(1,1)
-    rec.state = 1
-    rec_state_watcher:start()
-  end
-  --]]
   if rec.state == 1 and rec_state_watcher.is_running then
     rec_state_watcher:stop()
   end
@@ -2439,6 +2451,8 @@ function savestate()
   io.write("1.3.1".."\n")
   io.write("one_shot_clock_div: "..params:get("one_shot_clock_div").."\n")
   io.write("rec_loop_enc_resolution: "..params:get("rec_loop_enc_resolution").."\n")
+  io.write("more 1.3.1".."\n")
+  io.write("random_rec_clock_prob: "..params:get("random_rec_clock_prob").."\n")
   io.close(file)
   if selected_coll ~= params:get("collection") then
     meta_copy_coll(selected_coll,params:get("collection"))
@@ -2650,6 +2664,9 @@ function loadstate()
     if io.read() == "1.3.1" then
       params:set("one_shot_clock_div", tonumber(string.match(io.read(), ': (.*)')))
       params:set("rec_loop_enc_resolution", tonumber(string.match(io.read(), ': (.*)')))
+    end
+    if io.read() == "more 1.3.1" then
+      params:set("random_rec_clock_prob", tonumber(string.match(io.read(), ': (.*)')))
     end
     io.close(file)
     for i = 1,3 do

--- a/lib/grid_actions.lua
+++ b/lib/grid_actions.lua
@@ -321,15 +321,6 @@ function grid_actions.init(x,y,z)
         end
         
         if rec.loop == 0 and grid.alt == 0 then
-          --[[
-          softcut.position(1,rec.start_point)
-          if rec.state == 0 then
-            rec.state = 1
-            softcut.rec_level(1,1)
-            rec_state_watcher:start()
-            end
-          if rec.clear == 1 then rec.clear = 0 end
-          --]]
           clock.run(one_shot_clock)
         elseif rec.loop == 0 and grid.alt == 1 then
           buff_flush()

--- a/lib/start_up.lua
+++ b/lib/start_up.lua
@@ -97,7 +97,7 @@ function start_up.init()
     end
   )
 
-  params:add_option("one_shot_clock_div","--> 1-shot sync",{"next beat","next bar"},1)
+  params:add_option("one_shot_clock_div","--> 1-shot sync",{"next beat","next bar","free"},1)
 
   params:add_option("rec_loop_enc_resolution", "rec loop enc resolution", {"0.1","0.01","1/16","1/8","1/4","1/2","1 bar"}, 1)
   params:set_action("rec_loop_enc_resolution", function(x)

--- a/lib/start_up.lua
+++ b/lib/start_up.lua
@@ -66,7 +66,7 @@ function start_up.init()
   
   --params:add_separator()
   
-  params:add_group("loops + buffers", 13)
+  params:add_group("loops + buffers", 14)
 
   params:add_separator("clips")
   
@@ -136,6 +136,8 @@ function start_up.init()
     local rate_offset = {0,-12,-24}
     params:set("offset",rate_offset[x])
   end)
+
+  params:add_control("random_rec_clock_prob", "random rec probability", controlspec.new(0, 100, 'lin', 1, 0, "%"))
 
   params:add_separator("global")
 


### PR DESCRIPTION
CHANGELOG

1.3.1: released May 4, 2020

Watch a thorough walkthrough of these features: https://youtu.be/dNlWIG53YBQ

_live buffer improvements_

- NEW: PARAMS > ‘1-shot sync’ allows 1-shot buffer recording to sync to the global clock, to capture clean quantized recordings. Options include ‘next beat’, ‘next bar’, and ‘free’ (no clock sync).
     - If set to ‘next beat’ or ‘next bar’, a running 1-shot recording will ignore additional triggers until it has reached the buffer window’s end-point.
- NEW: PARAMS > ‘rec loop encoder resolution’ will auto-align the live buffer window to the specified resolution and will clamp encoders to add, subtract, or shift at multiples of that resolution. Options include ‘0.1’ and ‘0.01’ (standard), as well as tempo-aware ‘1/16’, ‘1/8’, ‘1/4’, ‘1/2’ and ‘1 bar’. To get odd divisions or lengths greater than 1 bar, use encoders on the [loops] page (while the live buffer is highlighted) to add/subtract/move the loop window incrementally.
- NEW: PARAMS > ‘random rec probability’ can be set to randomly toggle recording into the selected section of the live buffer.
- CHANGE: PARAMS > ‘live buffer max’ adjustments will automatically enforce a ‘global pitch offset’ to match.

_auto-slice_

- NEW: ‘auto-slice bank’ feature will slice the current live buffer window across all of a bank’s pads. To perform the action, press grid-ALT + the first key in the row underneath the bank you wish to auto-slice the live buffer into.
- NEW: ‘auto-adjust buffer’ feature will adjust the live buffer’s window to match the window of the currently selected pad in a bank. To perform the action, press grid-ALT + the third key in the row underneath the bank whose pad you wish the live buffer to mirror.

_new default state_

- CHANGE: when loading a fresh cheat codes session, live buffer will not be automatically engaged/recording.
- CHANGE: when loading a fresh cheat codes session, pads will be set to 1-shot (previously, set to loop).

_etc_

- FIXED: if a collections-saved grid Pattern included a pad that was raised by a fifth, the Pattern would stop playing when it hit that pad.